### PR TITLE
- Connected Journal editor to Journal tree.

### DIFF
--- a/src/journal.html
+++ b/src/journal.html
@@ -26,7 +26,6 @@
 </head>
 
 <body>
-	<journal-editor></journal-editor>
 	
     <script src="scripts/components/sidebar.js"></script>
     <script src="scripts/components/journal_tree.js" type="module"></script>
@@ -59,7 +58,7 @@
 
 
     <div id="journal-view">
-        <p id="journal-view-text"> No Journal Selected </p>
+        <journal-editor></journal-editor>
     </div>
 
     <button id="expand-button" class="expand">&gt;&gt;</button>

--- a/src/scripts/components/journal_tree.js
+++ b/src/scripts/components/journal_tree.js
@@ -191,10 +191,10 @@ export function setJournalViewer(path) {
     journalViewer.innerHTML = ""; // CLEAR whatever is displayed to the right
     const journalToLoad = getJournal(path); // Load in the corresponding journal from the database
 
-    // Temporarily just displays the title as h1
-    const journalTitle = document.createElement("h1");
-    journalTitle.innerHTML = journalToLoad.title;
-    journalViewer.appendChild(journalTitle);
+    // Adds <journal-editor></journal-editor> to the journal viewer
+    const journalEditor = document.createElement("journal-editor");
+    journalEditor.data = journalToLoad;
+    journalViewer.appendChild(journalEditor);
 }
 
 // Function to recursively load all files into the HTML

--- a/src/test/e2e/journal.test.js
+++ b/src/test/e2e/journal.test.js
@@ -69,37 +69,4 @@ describe("Journal Page", () => {
 
         expect(noJournalMessage).to.equal(true);
     });
-    
-    test("journal editor should display when data is set", async () => {
-        // Check that editor is displayed
-        const editorDisplayed = await page.evaluate(() => {
-            const editor = document.querySelector("journal-editor");
-
-            const entry = {
-                title: "Journal Title",
-                tags: ["tag1", "tag2"],
-                path: "path/to/journal",
-				content: "# hello"
-            };
-
-			// TODO: click on a journal entry / create new journal here.
-            editor.data = entry;
-
-            const title = editor.shadowRoot.getElementById('journal-title');
-            if (title.hidden) return false;
-            if (title.value != entry.title) return false;
-            
-            const tags = editor.shadowRoot.getElementById('journal-tags');
-            if (tags.hidden) return false;
-            if (tags.value != entry.tags.join(', ')) return false;
-
-			const text = editor.shadowRoot.getElementById('text-editor');
-			if (text.hidden) return false;
-			if (text.value != "# hello") return false;
-
-            return true;
-        });
-
-        expect(editorDisplayed).to.equal(true);
-    });
 });

--- a/src/test/e2e/sidebar.test.js
+++ b/src/test/e2e/sidebar.test.js
@@ -31,7 +31,7 @@ describe('MySidebar E2E Tests', () => {
         });
         page = await browser.newPage();
         await page.goto("http://localhost:1002/index.html", { waitUntil: 'networkidle2' }); // Adjust the path to your HTML file
-    }, 3000);
+    }, 10000);
 
     afterAll(async () => {
         await browser.close();

--- a/src/test/e2e/tree-view.test.js
+++ b/src/test/e2e/tree-view.test.js
@@ -110,9 +110,9 @@ describe("Tree View", () => {
             if (tags.hidden) return false;
             if (tags.value != ["tag1"]) return false;
 
-			const text = editor.shadowRoot.getElementById('text-editor');
-			if (text.hidden) return false;
-			if (text.value != "Test Content") return false;
+            const text = editor.shadowRoot.getElementById('text-editor');
+            if (text.hidden) return false;
+            if (text.value != "Test Content") return false;
 
             return true;
         });

--- a/src/test/e2e/tree-view.test.js
+++ b/src/test/e2e/tree-view.test.js
@@ -26,7 +26,7 @@ describe("Tree View", () => {
         });
 
         browser = await puppeteer.launch({
-            headless: false,
+            headless: true,
             slowMo: 50,
             args: ["--no-sandbox", "--disable-setuid-sandbox"]
         });

--- a/src/test/e2e/tree-view.test.js
+++ b/src/test/e2e/tree-view.test.js
@@ -26,7 +26,7 @@ describe("Tree View", () => {
         });
 
         browser = await puppeteer.launch({
-            headless: true,
+            headless: false,
             slowMo: 50,
             args: ["--no-sandbox", "--disable-setuid-sandbox"]
         });
@@ -95,11 +95,29 @@ describe("Tree View", () => {
         await firstFolderButton.click(); // Open the folder again for the next test
     });
 
-    it('should load journal content on button click', async () => {
+    it('journal editor should display content on button click', async () => {
         const journalButton = await page.$('.journal-button');
         await journalButton.click();
-        const journalTitle = await page.$eval('#journal-view > h1', el => el.textContent);
-        expect(journalTitle).to.equal("Test Journal");
+
+        const editorDisplayed = await page.evaluate( async() => {
+            const editor = document.querySelector("journal-editor");
+
+            const title = editor.shadowRoot.getElementById('journal-title');
+            if (title.hidden) return false;
+            if (title.value != "Test Journal") return false;
+            
+            const tags = editor.shadowRoot.getElementById('journal-tags');
+            if (tags.hidden) return false;
+            if (tags.value != ["tag1"]) return false;
+
+			const text = editor.shadowRoot.getElementById('text-editor');
+			if (text.hidden) return false;
+			if (text.value != "Test Content") return false;
+
+            return true;
+        });
+
+        expect(editorDisplayed).to.equal(true);
     });
 
     it('should update tree view upon journal deletion', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Connected journal editor to tree, and merged one of the e2e tests

## Description
<!--- Describe your changes in detail -->
Made it so that when a journal is clicked on the journal tree, it creates a journal-editor element to the right of the tree that loads in the data from the journal.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
E2E test, manual

## Checklist
- [ ] All automated tests have been passed locally (unit / e2e / linter / coverage)
- [ ] New unit and E2E tests have been added to address the changes made
- [ ] Manual testing has been performed according to the provided instructions
- [ ] Code follows team's coding style, convention and standards
- [ ] Documentation has been updated to reflect relevant changes (if applicable)

## Screenshots (if applicable):
![image](https://github.com/cse110-sp24-group35/journal/assets/146861585/9b579bae-2d7f-4f37-bdff-54e0a63d60bd)
