### PR TITLE
- Make it so that completed tasks in calendar display with strikethrough

### DIFF
--- a/src/scripts/components/calendar-view.js
+++ b/src/scripts/components/calendar-view.js
@@ -14,8 +14,6 @@ document.addEventListener('DOMContentLoaded', () => {
     prevMonthBtn = document.getElementById('prev-month');
     nextMonthBtn = document.getElementById('next-month');
 
-    //initializeTask(); //FAKE SET OF TASKS. REMOVE LATER
-
     renderCalendar();
     addMonthNavigationListeners();
 });
@@ -26,26 +24,6 @@ document.addEventListener('keydown', function(event) {
         unselectAllDays();
     }
 });
-
-/**
- * Initializes the task list with a set of sample tasks.
- * This function is for testing purposes and should be removed in production.
- */
-export function initializeTask() {
-    tasks.set([]);
-    createTask("1", "Sample Task", "This is a sample task", "High", "PLANNED", Date.now() + 1000 * 32 * 60);
-    createTask("2", "Sample 2", "This is a sample task", "High", "PLANNED", Date.now() + 2000 * 60 * 60);
-    createTask("3", "Sample 3", "This is a sample task", "High", "PLANNED", Date.now() + 700000 * 57 * 60);
-    createTask("4", "Sample 3", "This is a sample task", "High", "PLANNED", Date.now() + -100000 * 60 * 60);
-    createTask("5", "Sample 5", "This is a sample task", "High", "PLANNED", Date.now() + 2000 * 57 * 60);
-    createTask("6", "Sample 6", "This is a sample task", "High", "PLANNED", Date.now() + 3000 * 57 * 60);
-    createTask("7", "Sample 7", "This is a sample task", "High", "PLANNED", Date.now() + 2000 * 57 * 60);
-    createTask("8", "Sample 8", "This is a sample task", "High", "PLANNED", Date.now() + 3000 * 57 * 60);
-
-    for (let i = 0; i < 30; i++) {
-        createTask(`${i + 9}`, `SampleAMPLEMPAPEPAMPEAP WATCH K-ON!! ${i + 9}`, "This is a sample task", "High", "PLANNED", Date.now() + 1000 * 57 * 60);
-    }
-}
 
 /**
  * Renders the calendar for the current month.
@@ -167,6 +145,8 @@ export function addTasksToDay(dayDiv, year, month, day, allTasks) {
             // Set the button text content to the formatted time and task title
             taskItem.textContent = `${formattedTime} - ${task.title}`;
             if (appendedTasks < 3 || isSelected) { //Prevents more than 3 tasks from being shown in the non-expanded view
+                if(task.status == "COMPLETED")
+                    taskItem.style.textDecoration = "line-through";
                 taskList.appendChild(taskItem);
             }
 

--- a/src/scripts/components/calendar-view.js
+++ b/src/scripts/components/calendar-view.js
@@ -1,4 +1,4 @@
-import { tasks, createTask } from "../database/stores/task.js";
+import { tasks } from "../database/stores/task.js";
 
 tasks.listen(() => renderCalendar());
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
- Very small fix: Make it so that completed tasks display as strikethrough in calendar view
- Deleted function to populate tasks with fake data

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I looked at it with my eyes. It was indeed struck-through.

## Checklist
- [ ] All automated tests have been passed locally (unit / e2e / linter / coverage)
- [ ] New unit and E2E tests have been added to address the changes made
- [ ] Manual testing has been performed according to the provided instructions
- [ ] Code follows team's coding style, convention and standards
- [ ] Documentation has been updated to reflect relevant changes (if applicable)

## Screenshots (if applicable):