### PR TITLE
Task: split category and status

### DIFF
--- a/src/scripts/components/calendar-view.js
+++ b/src/scripts/components/calendar-view.js
@@ -161,7 +161,7 @@ export function addTasksToDay(dayDiv, year, month, day, allTasks) {
 
             // Alert w/ task info. REPLACE WITH TASK POP-UP MODAL
             taskItem.addEventListener('click', () => {
-                alert(`Task: ${task.title}\nDescription: ${task.description}\nPriority: ${task.priority}\nStatus: ${task.status}\nDue At: ${formattedTime}`); // Replace with modal
+                alert(`Task: ${task.title}\nDescription: ${task.description}\nPriority: ${task.priority}\nStatus: ${task.status}\nCategory: ${task.category}\nDue At: ${formattedTime}`); // Replace with modal
             });
 
             // Set the button text content to the formatted time and task title

--- a/src/scripts/components/task.js
+++ b/src/scripts/components/task.js
@@ -24,8 +24,8 @@ function renderTaskPage() {
     main.innerHTML = ''; // Clear the board before re-rendering
 
     // Render task columns
-    statuses.get().forEach(status => {
-        const column = new TaskColumn(status);
+    statuses.get().forEach(category => {
+        const column = new TaskColumn(category);
         main.appendChild(column);
     });
 
@@ -35,15 +35,15 @@ function renderTaskPage() {
 
 // TaskColumn class
 class TaskColumn extends HTMLElement {
-    constructor(status) {
+    constructor(category) {
         super();
-        this.status = status;
-        this.columnId = status.id;
+        this.category = category;
+        this.columnId = category.id;
 
         this.innerHTML = `
             <section class="task-column" data-column-id="${this.columnId}">
                 <div class="task-column-header">
-                    <h2 class="column-title" name="task-column-title">${status.name}</h2>
+                    <h2 class="column-title" name="task-column-title">${category.name}</h2>
                 </div>
                 <button class="task-column-delete-button">X</button>
                 <div class="content">
@@ -68,7 +68,7 @@ class TaskColumn extends HTMLElement {
         const header = document.getElementById("header");
         const addCardButton = this.querySelector('.add-task-card-button');
         addCardButton.addEventListener('click', () => {
-            document.body.appendChild(new ModalCardPopup(this.status));
+            document.body.appendChild(new ModalCardPopup(this.category));
             box.style.display = "none";
             header.innerHTML = "Add a Task";
         });
@@ -99,7 +99,7 @@ class TaskColumn extends HTMLElement {
     moveCardToColumn(taskId, newColumnId) {
         const updatedTasks = tasks.get().map((task) => {
             if (task.id === taskId) {
-                return { ...task, status: newColumnId };
+                return { ...task, category: newColumnId };
             }
             return task;
         });
@@ -110,7 +110,7 @@ class TaskColumn extends HTMLElement {
         const cardContainer = this.querySelector('.task-card-container');
         cardContainer.innerHTML = '';
 
-        tasks.get().filter(task => task.status === this.columnId).forEach(task => {
+        tasks.get().filter(task => task.category === this.columnId).forEach(task => {
             const card = new TaskCard(task);
             cardContainer.appendChild(card);
         });
@@ -135,13 +135,13 @@ class TaskColumn extends HTMLElement {
         // Remove this specific column element from the DOM
         this.remove();
 
-        // Update statuses by filtering out the status of this column only once
+        // Update statuses by filtering out the category of this column only once
         let currentStatuses = statuses.get();
-        currentStatuses = currentStatuses.filter(status => status.id !== this.columnId);
+        currentStatuses = currentStatuses.filter(category => category.id !== this.columnId);
         statuses.set(currentStatuses);
 
         // Remove tasks associated with this column
-        const updatedTasks = tasks.get().filter(task => task.status !== this.columnId);
+        const updatedTasks = tasks.get().filter(task => task.category !== this.columnId);
         tasks.set(updatedTasks);
     }
 
@@ -245,7 +245,7 @@ class ModalCardPopupColumn extends HTMLElement {
 
         if (columnName) {
             const newStatus = {
-                id: `status-${Date.now()}`,
+                id: `category-${Date.now()}`,
                 name: columnName
             };
             const currentStatuses = statuses.get();
@@ -258,9 +258,9 @@ class ModalCardPopupColumn extends HTMLElement {
 
 // ModalCardPopup class
 class ModalCardPopup extends HTMLElement {
-    constructor(status, task = {}) {
+    constructor(category, task = {}) {
         super();
-        this.status = status;
+        this.category = category;
         this.task = task;
 
         const isEditing = !!task.id; // Determine if we are editing an existing task
@@ -345,7 +345,7 @@ class ModalCardPopup extends HTMLElement {
             date, // Keep the local date string for display
             tags,
             journal,
-            status: this.status.id, // Use the current status ID
+            category: this.category.id, // Use the current category ID
             createdAt: this.task.createdAt || Date.now(),
             dueAt: dueDate.getTime() // Convert the date to a timestamp in local time
         };
@@ -406,12 +406,12 @@ class TaskCard extends HTMLElement {
     }
 
     editCard() {
-        document.body.appendChild(new ModalCardPopup(statuses.get().find(status => status.id === this.task.status), this.task));
+        document.body.appendChild(new ModalCardPopup(statuses.get().find(category => category.id === this.task.category), this.task));
     }
 
     dragStartHandler(event) {
         event.dataTransfer.setData('application/card-id', this.task.id);
-        event.dataTransfer.setData('application/column-id', this.task.status);
+        event.dataTransfer.setData('application/column-id', this.task.category);
         event.dataTransfer.dropEffect = 'move';
     }
 }

--- a/src/scripts/database/stores/task.js
+++ b/src/scripts/database/stores/task.js
@@ -8,6 +8,7 @@ import { persistentAtom } from '@nanostores/persistent';
  * @property {string} description - The task description
  * @property {string} priority - The task priority
  * @property {string} status - Task status, can be one of "PLANNED", "ONGOING", "COMPLETED", "ABANDONED"
+ * @property {string} category - The task category. Determines which category the task appears under
  * @property {number} createdAt - The timestamp when task has been created
  * @property {number} dueAt - The timestamp when a task is "due"
  */
@@ -61,10 +62,11 @@ export function deleteTask(id) {
  * @param {string} description - The task description
  * @param {string} priority - The task priority
  * @param {string} status - Task status, can be one of "PLANNED", "ONGOING", "COMPLETED", "ABANDONED"
+ * @param {string} category - The task category. Determines which category the task appears under
  * @param {number} dueAt - The timestamp when a task is "due"
  * @throws {Error} - When there is already a task with the specified ID
  */
-export function createTask(id, title, description, priority, status, dueAt) {
+export function createTask(id, title, description, priority, status, category, dueAt) {
     if (getTask(id)) throw new Error(`Task with ID ${id} already exists!`);
 
     const dueDate = new Date(dueAt); // This will parse the date as local time
@@ -76,6 +78,7 @@ export function createTask(id, title, description, priority, status, dueAt) {
         description,
         priority,
         status,
+        category,
         createdAt: Date.now(),
         dueAt: dueDate.getTime()
     };
@@ -92,13 +95,14 @@ export function createTask(id, title, description, priority, status, dueAt) {
  * @param {string} [modified.description] - The new task description (optional)
  * @param {string} [modified.priority] - The new task priority (optional)
  * @param {string} [modified.status] - The new task status (optional)
+ * @param {string} [modified.category] - The new task category (optional_
  * @param {number} [modified.dueAt] - The new due date timestamp (optional)
  * @returns {boolean} - Whether the task has been updated successfully or not (true / false)
  * @param id - The task ID
  * @param modified - The modified object
  */
 export function updateTask(id, modified) {
-    const { title, description, priority, status, dueAt } = modified;
+    const { title, description, priority, status, category, dueAt } = modified;
 
     let taskFound = false;
 
@@ -111,6 +115,7 @@ export function updateTask(id, modified) {
                 ...(description !== undefined && { description }),
                 ...(priority !== undefined && { priority }),
                 ...(status !== undefined && { status }),
+                ...(category !== undefined && { category }),
                 ...(dueAt !== undefined && { dueAt }),
             };
         }

--- a/src/test/e2e/calendar.test.js
+++ b/src/test/e2e/calendar.test.js
@@ -68,7 +68,7 @@ describe("Calendar View", () => {
 
         await page.evaluate(async () => {
             const helper = await import("./scripts/database/stores/task.js");
-            helper.createTask("myID", "myTitle", "myDescription", "High", "PLANNED", Date.now());
+            helper.createTask("myID", "myTitle", "myDescription", "High", "PLANNED", "SomeCategory", Date.now());
         });
 
         dayTaskItems = await page.$$('.day-task-item');
@@ -81,10 +81,10 @@ describe("Calendar View", () => {
 
         await page.evaluate(async () => {
             const helper = await import("./scripts/database/stores/task.js");
-            helper.createTask("myID2", "myTitle", "myDescription", "High", "PLANNED", Date.now());
-            helper.createTask("myID3", "myTitle", "myDescription", "High", "PLANNED", Date.now());
-            helper.createTask("myID4", "myTitle", "myDescription", "High", "PLANNED", Date.now());
-            helper.createTask("myID5", "myTitle", "myDescription", "High", "PLANNED", Date.now());
+            helper.createTask("myID2", "myTitle", "myDescription", "High", "PLANNED", "SomeCategory", Date.now());
+            helper.createTask("myID3", "myTitle", "myDescription", "High", "PLANNED", "SomeCategory", Date.now());
+            helper.createTask("myID4", "myTitle", "myDescription", "High", "PLANNED", "SomeCategory", Date.now());
+            helper.createTask("myID5", "myTitle", "myDescription", "High", "PLANNED", "SomeCategory", Date.now());
         });
 
         let dayTaskItems = await page.$$('.day-task-item');

--- a/src/test/e2e/task.test.js
+++ b/src/test/e2e/task.test.js
@@ -45,7 +45,7 @@ describe('Kanban Board E2E Test', () => {
     await page.click('body > modal-card-popup-column > dialog > form > div > button');
 
     // Wait for the new column to appear
-    await page.waitForSelector('.task-column[data-column-id*="status-"]');
+    await page.waitForSelector('.task-column[data-column-id*="category-"]');
 
     // Add a new task to the new column
     await page.click("#container > main > task-column > section > div.add-button > button");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the bug where marking a task as completed in the overview page removes it from the tasks page

## Description
<!--- Describe your changes in detail -->
- Create a new category property in stores/task.js
- replace all uses of task.status with task.category in components/task.js

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I looked at it with my eyes 

## Checklist
- [ ] All automated tests have been passed locally (unit / e2e / linter / coverage)
- [ ] New unit and E2E tests have been added to address the changes made
- [ ] Manual testing has been performed according to the provided instructions
- [ ] Code follows team's coding style, convention and standards
- [ ] Documentation has been updated to reflect relevant changes (if applicable)

## Screenshots (if applicable):