### PR TITLE
Ethan/close modal fix

### DIFF
--- a/src/scripts/components/task-pop-up.js
+++ b/src/scripts/components/task-pop-up.js
@@ -62,6 +62,11 @@ class TaskModal extends HTMLElement {
                 this.closeModal();
             }
         });
+        this.shadowRoot.getElementById('taskModal').addEventListener('click', (event) => {
+            if (event.target === this.shadowRoot.getElementById('taskModal')) {
+                this.closeModal();
+            }
+        });
     }
 
     openModal(task) {


### PR DESCRIPTION
Made it so that if you click outside the modal it will close the modal for task-pop-up on calendar.